### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ Configure Nginx to reverse proxy the n8n web interface:
             proxy_cache off;
             proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_cache_bypass $http_upgrade;
+            proxy_set_header X-Real-IP $remote_addr;
         }
     }
     ```


### PR DESCRIPTION
docs: add reverse proxy configuration instructions in Nginx to support WebSocket in n8n

Added essential directives to the Nginx `location` block to ensure proper WebSocket connection handling with n8n. This configuration addresses the "Connection Lost" error by forwarding the required headers and maintaining a persistent connection.